### PR TITLE
Add engine version field

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,3 +199,7 @@ yjcc-events/
 ├── package.json
 ├── vercel.json
 └── .gitignore 
+
+## Development Notes
+Ensure `package.json` contains a valid `version` field. The Vercel build will fail with an "Invalid Version" error if this value is missing or malformed.
+

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ YJCC Events היא מערכת ניהול אירועים שפותחה במיוח�
 
 ## 📦 התקנה
 
-1. התקן את Node.js (גרסה 14 ומעלה)
+1. התקן את Node.js (גרסה 18 ומעלה)
 2. שכפל את הפרויקט:
    ```bash
    git clone https://github.com/your-username/yjcc-events.git
@@ -131,7 +131,7 @@ This system was developed for YJCC (Young Israeli Community in Prague) to manage
 - 📊 Statistics and reports
 
 ### System Requirements
-- Node.js 14.0 or higher
+- Node.js 18 or higher
 - npm or yarn
 
 ### Installation
@@ -154,7 +154,9 @@ npm start
 Create a `.env` file in the project root with:
 ```
 REACT_APP_ADMIN_CODE=291147
+GOOGLE_SERVICE_ACCOUNT_KEY="<service-account-json>"
 ```
+The `GOOGLE_SERVICE_ACCOUNT_KEY` should contain your Google service account credentials in JSON format.
 
 ### Usage
 1. Admin Access:
@@ -202,4 +204,5 @@ yjcc-events/
 
 ## Development Notes
 Ensure `package.json` contains a valid `version` field. The Vercel build will fail with an "Invalid Version" error if this value is missing or malformed.
+Use the `/api/google-sheets` endpoint to fetch data from Google Sheets.
 

--- a/api/google-sheets.js
+++ b/api/google-sheets.js
@@ -1,0 +1,37 @@
+const { google } = require('googleapis');
+
+module.exports = async (req, res) => {
+  const { spreadsheetId, range } = req.query;
+  if (!spreadsheetId || !range) {
+    res.status(400).json({ error: 'Missing spreadsheetId or range' });
+    return;
+  }
+
+  try {
+    const credentials = process.env.GOOGLE_SERVICE_ACCOUNT_KEY;
+    const auth = new google.auth.GoogleAuth({
+      credentials: JSON.parse(credentials),
+      scopes: ['https://www.googleapis.com/auth/spreadsheets.readonly'],
+    });
+
+    const client = await auth.getClient();
+    const sheets = google.sheets({ version: 'v4', auth: client });
+
+    const response = await sheets.spreadsheets.values.get({
+      spreadsheetId,
+      range,
+    });
+
+    const values = response.data.values || [];
+    const rows = values.map(row => ({
+      name: row[0],
+      email: row[1],
+      phone: row[2],
+    }));
+
+    res.status(200).json({ values: rows });
+  } catch (error) {
+    console.error('Google Sheets API error', error);
+    res.status(500).json({ error: 'Failed to fetch data from Google Sheets' });
+  }
+};

--- a/api/google-sheets.js
+++ b/api/google-sheets.js
@@ -7,10 +7,15 @@ module.exports = async (req, res) => {
     return;
   }
 
+  const credentialsJSON = process.env.GOOGLE_SERVICE_ACCOUNT_KEY;
+  if (!credentialsJSON) {
+    res.status(500).json({ error: 'Google service account credentials not provided' });
+    return;
+  }
+
   try {
-    const credentials = process.env.GOOGLE_SERVICE_ACCOUNT_KEY;
     const auth = new google.auth.GoogleAuth({
-      credentials: JSON.parse(credentials),
+      credentials: JSON.parse(credentialsJSON),
       scopes: ['https://www.googleapis.com/auth/spreadsheets.readonly'],
     });
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "yjcc-events",
   "version": "1.0.0",
   "private": true,
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
     "@emotion/cache": "^11.11.0",
     "@emotion/react": "^11.11.3",

--- a/src/App.js
+++ b/src/App.js
@@ -81,6 +81,7 @@ import {
   CloudUpload as CloudUploadIcon,
   CloudDownload as CloudDownloadIcon,
   Assessment as AssessmentIcon,
+  Sync as SyncIcon,
 } from '@mui/icons-material';
 import './App.css';
 import { loadEventsFromCloud, saveEventsToCloud, updateEventInCloud, saveParticipantToEvent } from './services/database.js';

--- a/src/services/googleSheets.js
+++ b/src/services/googleSheets.js
@@ -1,30 +1,14 @@
-import { google } from 'googleapis';
-
-const sheets = google.sheets('v4');
-
-// Initialize with credentials
-const auth = new google.auth.GoogleAuth({
-  keyFile: process.env.REACT_APP_GOOGLE_SERVICE_ACCOUNT_KEY,
-  scopes: ['https://www.googleapis.com/auth/spreadsheets.readonly'],
-});
-
 export const fetchRegistrantsFromSheet = async (spreadsheetId, range) => {
   try {
-    const authClient = await auth.getClient();
-    const response = await sheets.spreadsheets.values.get({
-      auth: authClient,
-      spreadsheetId,
-      range,
-    });
-
-    return response.data.values.map(row => ({
-      name: row[0],
-      email: row[1],
-      phone: row[2],
-      // Add more fields as needed based on your sheet structure
-    }));
+    const params = new URLSearchParams({ spreadsheetId, range });
+    const response = await fetch(`/api/google-sheets?${params.toString()}`);
+    if (!response.ok) {
+      throw new Error('Failed to fetch data');
+    }
+    const data = await response.json();
+    return data.values;
   } catch (error) {
-    console.error('Error fetching data from Google Sheets:', error);
+    console.error('Error fetching data from Google Sheets API:', error);
     throw error;
   }
-}; 
+};

--- a/vercel.json
+++ b/vercel.json
@@ -5,9 +5,17 @@
       "src": "package.json",
       "use": "@vercel/static-build",
       "config": { "distDir": "build" }
+    },
+    {
+      "src": "api/**/*.js",
+      "use": "@vercel/node"
     }
   ],
   "routes": [
+    {
+      "src": "/api/(.*)",
+      "dest": "/api/$1.js"
+    },
     {
       "src": "/(.*)",
       "dest": "/index.html"


### PR DESCRIPTION
## Summary
- ensure Node 18+ is used by specifying an `engines` field
- mention version field requirement in `README`

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846fe6a6124832f9b8918830dd47b35