### PR TITLE
Add example env file and update setup docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+REACT_APP_FIREBASE_API_KEY=your-api-key
+REACT_APP_FIREBASE_AUTH_DOMAIN=your-auth-domain
+REACT_APP_FIREBASE_DATABASE_URL=your-database-url
+REACT_APP_FIREBASE_PROJECT_ID=your-project-id
+REACT_APP_FIREBASE_STORAGE_BUCKET=your-storage-bucket
+REACT_APP_FIREBASE_MESSAGING_SENDER_ID=your-messaging-sender-id
+REACT_APP_FIREBASE_APP_ID=your-app-id
+REACT_APP_GOOGLE_SERVICE_ACCOUNT_KEY=path/to/service-account-key.json
+REACT_APP_ADMIN_CODE=your-admin-code

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Node dependencies
+node_modules/
+
+# Production build
+build/
+
+# Environment variables
+.env
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# OS files
+.DS_Store
+
+# Other
+*.local
+

--- a/README.md
+++ b/README.md
@@ -151,10 +151,12 @@ npm start
 ```
 
 ### Environment Setup
-Create a `.env` file in the project root with:
-```
-REACT_APP_ADMIN_CODE=291147
-```
+1. Copy `.env.example` to `.env` in the project root:
+   ```bash
+   cp .env.example .env
+   ```
+2. Fill in values for each variable in `.env`.
+3. When deploying to Vercel, set the same variables in your project settings.
 
 ### Usage
 1. Admin Access:


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholders for all `REACT_APP_*` variables
- document environment setup in README
- ignore `.env` and other build artifacts with `.gitignore`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68470ade3ff8832fae9afd13ce2b78ae