### PR TITLE
Fix missing SyncIcon import

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -81,6 +81,7 @@ import {
   CloudUpload as CloudUploadIcon,
   CloudDownload as CloudDownloadIcon,
   Assessment as AssessmentIcon,
+  Sync as SyncIcon,
 } from '@mui/icons-material';
 import './App.css';
 import { loadEventsFromCloud, saveEventsToCloud, updateEventInCloud, saveParticipantToEvent } from './services/database.js';


### PR DESCRIPTION
## Summary
- import `Sync` icon as `SyncIcon` in the main App

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684715fabb1c832f9ca7c2e2732f9080