### PR TITLE
Fix SyncIcon import

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -80,6 +80,7 @@ import {
   PieChart as PieChartIcon,
   CloudUpload as CloudUploadIcon,
   CloudDownload as CloudDownloadIcon,
+  Sync as SyncIcon,
   Assessment as AssessmentIcon,
 } from '@mui/icons-material';
 import './App.css';


### PR DESCRIPTION
## Summary
- add missing SyncIcon import to App.js

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684717b9ceb4832f8e9cb7cf616ffbd7