### PR TITLE
Fix Sync icon import

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -81,6 +81,7 @@ import {
   CloudUpload as CloudUploadIcon,
   CloudDownload as CloudDownloadIcon,
   Assessment as AssessmentIcon,
+  Sync as SyncIcon,
 } from '@mui/icons-material';
 import './App.css';
 import { loadEventsFromCloud, saveEventsToCloud, updateEventInCloud, saveParticipantToEvent } from './services/database.js';


### PR DESCRIPTION
## Summary
- fix missing SyncIcon import to resolve undefined symbol

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68474ceb6738832f8a9378e4d61e2c72