### PR TITLE
Fix google sheets browser build error

### DIFF
--- a/src/services/googleSheets.js
+++ b/src/services/googleSheets.js
@@ -1,30 +1,9 @@
-import { google } from 'googleapis';
-
-const sheets = google.sheets('v4');
-
-// Initialize with credentials
-const auth = new google.auth.GoogleAuth({
-  keyFile: process.env.REACT_APP_GOOGLE_SERVICE_ACCOUNT_KEY,
-  scopes: ['https://www.googleapis.com/auth/spreadsheets.readonly'],
-});
+import axios from 'axios';
 
 export const fetchRegistrantsFromSheet = async (spreadsheetId, range) => {
-  try {
-    const authClient = await auth.getClient();
-    const response = await sheets.spreadsheets.values.get({
-      auth: authClient,
-      spreadsheetId,
-      range,
-    });
-
-    return response.data.values.map(row => ({
-      name: row[0],
-      email: row[1],
-      phone: row[2],
-      // Add more fields as needed based on your sheet structure
-    }));
-  } catch (error) {
-    console.error('Error fetching data from Google Sheets:', error);
-    throw error;
-  }
-}; 
+  const response = await axios.post('/api/google-sheets', {
+    spreadsheetId,
+    range,
+  });
+  return response.data.registrants;
+};


### PR DESCRIPTION
## Summary
- move Google Sheets API access to server
- add server route `/api/google-sheets`
- call server route from front-end instead of using `googleapis` in the browser

## Testing
- `npm test --silent -- -w 1000` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68474dbc91ec832f8c6665d1bfbbc1bf